### PR TITLE
Adding another in-app phishing reference for phishing lures embedded …

### DIFF
--- a/techniques/in-app_phishing/description.md
+++ b/techniques/in-app_phishing/description.md
@@ -23,4 +23,4 @@ For example, a malicious document could be shared with a target using a document
 * [Jade sleet compromise using GitHub repository collaboration](https://github.blog/2023-07-18-security-alert-social-engineering-campaign-targets-technology-industry-employees/)
 * [Evilginx - MITM framework for phishing login credentials](https://github.com/kgretzky/evilginx2)
 * [MITRE ATT&CK - Phishing: Spearphishing via Service](https://attack.mitre.org/techniques/T1566/003/)
-
+* [Technical blog - Phishing lures embedded within shared documents](https://www.proofpoint.com/uk/blog/cloud-security/community-alert-ongoing-malicious-campaign-impacting-azure-cloud-environments)


### PR DESCRIPTION
…in shared documents. It's not 100% clear if they were cloud shared documents, but it seems the most likely case